### PR TITLE
project: make github link open in the same tab

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,5 @@ import formatRepoUrl from './formatter'
 
 chrome.omnibox.onInputEntered.addListener((input) => {
   const ghUrl = formatRepoUrl(input)
-  chrome.tabs.create({ url: ghUrl })
+  chrome.tabs.update({ url: ghUrl })
 })


### PR DESCRIPTION
## Description

Before the code called `chrome.tabs.create` with an URL,
this would open the given Github page in a new Tab.
Just by changing it to `chrome.tabs.update`, it makes the
URL open in the same Tab, this creates a better user
experience.

### Checklist

- [ ] Does it have tests? Nope
- [ ] Did you followed the styleguide? I guess...